### PR TITLE
RFC: Add the ability to make an existing struct an overlay pass

### DIFF
--- a/src/CassetteOverlay.jl
+++ b/src/CassetteOverlay.jl
@@ -151,12 +151,28 @@ end
     end
 end
 
-macro overlaypass(method_table)
-    PassName = esc(gensym(string(method_table)))
+macro overlaypass(args...)
+    if length(args) == 1
+        PassName = nothing
+        method_table = args[1]
+    else
+        PassName, method_table = args
+    end
+
+    if PassName === nothing
+        PassName = esc(gensym(string(method_table)))
+        decl_pass = :(struct $PassName <: $OverlayPass end)
+        ret = :($PassName())
+    else
+        PassName = esc(PassName)
+        decl_pass = :(@assert $PassName <: $OverlayPass)
+        ret = nothing
+    end
+
     nonoverlaytype = typeof(CassetteOverlay.nonoverlay)
 
     blk = quote
-        struct $PassName <: $OverlayPass end
+        $decl_pass
 
         $CassetteOverlay.method_table(::Type{$PassName}) = $(esc(method_table))
 
@@ -192,7 +208,7 @@ macro overlaypass(method_table)
             end
         end
 
-        return $PassName()
+        return $ret
     end
 
     return Expr(:toplevel, blk.args...)


### PR DESCRIPTION
The macro adds a bunch of methods now, so if we want to use our own struct (e.g. to add some fields), need need to be able to pass in the name of the struct. An alternative design would be to put the macro on the struct definition or to make the methods all on the abstract type, so that any subtype is automatically enrolled.