### PR TITLE
Add an easy abstract type interface

### DIFF
--- a/test/abstract.jl
+++ b/test/abstract.jl
@@ -1,0 +1,23 @@
+module abstract
+
+using CassetteOverlay, Test
+@MethodTable SinTable
+mutable struct CosCounter <: CassetteOverlay.AbstractBindingOverlay{@__MODULE__, :SinTable}
+    ncos::Int
+end
+
+function (c::CosCounter)(::typeof(cos), args...)
+    c.ncos += 1
+    return cos(args...)
+end
+
+@overlay SinTable sin(x::Union{Float32,Float64}) = cos(x);
+
+let pass! = CosCounter(0)
+    pass!(42) do a
+        sin(a) * cos(a)
+    end
+    @test pass!.ncos == 2
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
     @testset "simple" include("simple.jl")
     @testset "math" include("math.jl")
     @testset "misc" include("misc.jl")
+    @testset "abstract" include("abstract.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,5 +4,8 @@ using Test
     @testset "simple" include("simple.jl")
     @testset "math" include("math.jl")
     @testset "misc" include("misc.jl")
-    @testset "abstract" include("abstract.jl")
+    if VERSION >= v"1.10.0-DEV.90"
+        # This interface depends on julia#47749
+        @testset "abstract" include("abstract.jl")
+    end
 end


### PR DESCRIPTION
Can be used in place of the macro to give a pass CassetteoOverlay behavior. The abstract type works by reading the appropriate binding from the type parameter.

Requires https://github.com/JuliaLang/julia/pull/47749