### PR TITLE
Allow AbstractBindingOverlay to use the internal method table

### DIFF
--- a/src/CassetteOverlay.jl
+++ b/src/CassetteOverlay.jl
@@ -233,6 +233,9 @@ end
 
 abstract type AbstractBindingOverlay{M, S} <: OverlayPass; end
 function method_table(::Type{<:AbstractBindingOverlay{M, S}}) where {M, S}
+    if M === nothing
+        return nothing
+    end
     @assert isconst(M, S)
     return getglobal(M, S)::Core.MethodTable
 end


### PR DESCRIPTION
By returning `nothing` from `method_table`. Useful for testing.