### PR TITLE
Instantiate rt and at for :foreigncall during overlay

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -21,4 +21,6 @@ using NaNMath
     sin("1")
 end
 
+@test isa(pass(pointer, Int[1]), Ptr{Int})
+
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/CassetteOverlay.jl/issues/27.