### PR TITLE
fix up `Core.Compiler.return_type` special case

### DIFF
--- a/src/CassetteOverlay.jl
+++ b/src/CassetteOverlay.jl
@@ -215,9 +215,9 @@ macro overlaypass(args...)
             @nospecialize f args
             return f(args...)
         end
-        @inline function (::$PassName)(f::typeof(Core.Compiler.return_type), args...)
+        @inline function (self::$PassName)(f::typeof(Core.Compiler.return_type), args...)
             @nospecialize args
-            return f(args...)
+            return Core.Compiler.return_type(self, args...)
         end
         @inline function (self::$PassName)(::typeof(Core._apply_iterate), iterate, f, args...)
             @nospecialize args

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -6,7 +6,6 @@ using CassetteOverlay, Test
 pass = @overlaypass MiscTable
 
 # Issue #9 – Core.Compiler.return_type needs a special casing
-# TODO support invalidation mechanism for overlayed method
 function strange_sin end
 
 @overlay MiscTable strange_sin(x) = sin(x);

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -6,11 +6,20 @@ using CassetteOverlay, Test
 pass = @overlaypass MiscTable
 
 # Issue #9 – Core.Compiler.return_type needs a special casing
-@test pass(sin, 1) do f, args...
+# TODO support invalidation mechanism for overlayed method
+function strange_sin end
+
+@overlay MiscTable strange_sin(x) = sin(x);
+@test pass(strange_sin, 1) do f, args...
     tt = Base.signature_type(f, Any[Core.Typeof(a) for a = args])
-    T = Core.Compiler.return_type(tt)
-    T[]
-end == Float64[]
+    return Core.Compiler.return_type(tt)
+end == Float64
+
+@overlay MiscTable strange_sin(x) = 0;
+@test pass(strange_sin, 1) do f, args...
+    tt = Base.signature_type(f, Any[Core.Typeof(a) for a = args])
+    return Core.Compiler.return_type(tt)
+end == Int
 
 # Issue #14 - :foreigncall first argument mapping
 using NaNMath


### PR DESCRIPTION
Make `return_type` inference account for overlays.