### PR TITLE
fixup! fix up `Core.Compiler.return_type` special case

### DIFF
--- a/src/CassetteOverlay.jl
+++ b/src/CassetteOverlay.jl
@@ -215,9 +215,12 @@ macro overlaypass(args...)
             @nospecialize f args
             return f(args...)
         end
-        @inline function (self::$PassName)(f::typeof(Core.Compiler.return_type), args...)
-            @nospecialize args
-            return Core.Compiler.return_type(self, args...)
+        @inline function (self::$PassName)(::typeof(Core.Compiler.return_type), tt::DataType)
+            return Core.Compiler.return_type(self, tt)
+        end
+        @inline function (self::$PassName)(::typeof(Core.Compiler.return_type), f, tt::DataType)
+            newtt = Base.signature_type(f, tt)
+            return Core.Compiler.return_type(self, newtt)
         end
         @inline function (self::$PassName)(::typeof(Core._apply_iterate), iterate, f, args...)
             @nospecialize args

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -13,11 +13,19 @@ function strange_sin end
     tt = Base.signature_type(f, Any[Core.Typeof(a) for a = args])
     return Core.Compiler.return_type(tt)
 end == Float64
+@test pass(1) do args...
+    tt = Tuple{Any[Core.Typeof(a) for a = args]...}
+    return Core.Compiler.return_type(strange_sin, tt)
+end == Float64
 
 @overlay MiscTable strange_sin(x) = 0;
 @test pass(strange_sin, 1) do f, args...
     tt = Base.signature_type(f, Any[Core.Typeof(a) for a = args])
     return Core.Compiler.return_type(tt)
+end == Int
+@test pass(1) do args...
+    tt = Tuple{Any[Core.Typeof(a) for a = args]...}
+    return Core.Compiler.return_type(strange_sin, tt)
 end == Int
 
 # Issue #14 - :foreigncall first argument mapping


### PR DESCRIPTION
JuliaDebug/CassetteOverlay.jl#30 was incomplete because it only handles `Core.Compiler.return_type(tt::DataType)` but does not properly handle `Core.Compiler.return_type(f, tt::DataType)`.
This commit fixes up the handling of the later case.