### PR TITLE
fix up the adjustments for v1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CassetteOverlay"
 uuid = "d78b62d4-37fa-4a6f-acd8-2f19986eb9ee"
 authors = ["JuliaHub, Inc. and other contributors"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/CassetteOverlay.jl
+++ b/src/CassetteOverlay.jl
@@ -110,11 +110,10 @@ function overlay_transform!(src::CodeInfo, mi::MethodInstance, nargs::Int)
         ssaid += 1
     end
     prepend!(code, precode)
-    if VERSION < v"1.12.0-DEV.173"
+    @static if VERSION < v"1.12.0-DEV.173"
         prepend!(src.codelocs, [0 for i = 1:ssaid])
     else
         di = Core.Compiler.DebugInfoStream(mi, src.debuginfo, length(code))
-        prepend!(di.codelocs, fill(Int32(0), 3ssaid))
         src.debuginfo = Core.DebugInfo(di, length(code))
     end
     prepend!(src.ssaflags, [0x00 for i = 1:ssaid])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test
     @testset "simple" include("simple.jl")
     @testset "math" include("math.jl")
     @testset "misc" include("misc.jl")
-    if VERSION >= v"1.10.0-DEV.90"
+    @static if VERSION >= v"1.10.0-DEV.90"
         # This interface depends on julia#47749
         @testset "abstract" include("abstract.jl")
     end


### PR DESCRIPTION
The `Core.Compiler.DebugInfoStream(mi, src.debuginfo, length(code))` constructor creates `codelocs` whose length is `3 * length(code)`.