### PR TITLE
add a fallback implementation for `(pass::$PassName)(fargs...)`

### DIFF
--- a/test/simple.jl
+++ b/test/simple.jl
@@ -67,4 +67,19 @@ let pass = @overlaypass Issue8.Issue8Table
     @test pass(identity, 42) == nothing
 end
 
-end
+# JuliaDebug/CassetteOverlay#39 & JuliaDebug/CassetteOverlay#45:
+# use the fallback implementation for `!isdispatchtuple` dynamic dispatches
+issue39() = UnionAll(TypeVar(:T,Integer), Array{TypeVar(:T,Integer)})
+@test pass() do
+    issue39()
+end isa UnionAll
+
+issue45(x::UnionAll) = issue45(x.body)
+issue45(x) = x
+@test pass(issue45, NamedTuple) == issue45(NamedTuple)
+
+pr46_regression(x::UnionAll) = pr46_regression(x.body)
+pr46_regression(x) = myidentity(x)
+@test_broken pass(fallback_regression, NamedTuple) == 42
+
+end # module simple


### PR DESCRIPTION
When dynamic dispatch occurs for the generated function and the dispatch signature is `!isdispatchtuple` (e.g. since it includes a `Type`-object argument with a free type variable), it will result in unintended code generation, leading to issues like #39 and #45.
In this commit, the generated function is now not marked as `:generated_only`, and it will simply fallback to original implementations.

This fix introduces a regression where overlays will not occur for the entire call graph of such `!isdispatchtuple` dynamic dispatches. But since it would require a redesign of the runtime system to completely resolve this issue, this regression seems to be acceptable for now.

- fixes #39 
- fixes #45 