### PR TITLE
Adjust to JuliaLang/julia#59915

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CassetteOverlay"
 uuid = "d78b62d4-37fa-4a6f-acd8-2f19986eb9ee"
-authors = ["JuliaHub, Inc. and other contributors"]
 version = "0.2.3"
+authors = ["JuliaHub, Inc. and other contributors"]
 
 [deps]
 CassetteBase = "6dd3e646-b1c5-42c7-94be-00277fa12e22"

--- a/src/CassetteOverlay.jl
+++ b/src/CassetteOverlay.jl
@@ -105,7 +105,8 @@ macro overlaypass(args...)
     nonoverlaytype = typeof(CassetteOverlay.nonoverlay)
 
     if method_table !== :nothing
-        mthd_tbl = :($CassetteOverlay.methodtable(::UInt, ::Type{$PassName}) = $(esc(method_table)))
+        mthd_tbl = :($CassetteOverlay.methodtable(world::UInt, ::Type{$PassName}) =
+            Base.Compiler.OverlayMethodTable(world, $(esc(method_table))))
     else
         mthd_tbl = nothing
     end
@@ -193,7 +194,8 @@ function methodtable(world::UInt, ::Type{<:AbstractBindingOverlay{M, S}}) where 
     end
     @static if VERSION ≥ v"1.12-"
         @assert isconst_at_world(M, S, world)
-        return getglobal_at_world(M, S, world)
+        mt, worlds = getglobal_at_world(M, S, world)
+        return Base.Compiler.OverlayMethodTable(world, mt::MethodTable) => worlds
     else
         @assert @invokelatest isconst(M, S)
         return getglobal(M, S)::MethodTable


### PR DESCRIPTION
Since JuliaLang/julia#59915, `Base._which` now takes `Compiler.MethodTableView` instead of `MethodTable`, so this change is necessary.

However, with this change, it seems that CassetteOverlay and external abstract interpreter packages cannot be composed. If this becomes necessary, we may need to change the interface of
`CassetteOverlay.method_table`.